### PR TITLE
Fetch news from the Newsful API instead of the dead Currents API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Optional environment variables (put them in `.env.local`):
 | Variable | Purpose | Default |
 | --- | --- | --- |
 | `VITE_API_ENDPOINT` | Newsful API base URL | `https://newsful-api.onrender.com/api` |
-| `VITE_CURRENTS_API_KEY` | [Currents API](https://currentsapi.services) key for news data | bundled demo key |
+
+News comes from the Newsful API, which aggregates free Google News RSS feeds per outlet — there is no news-API key to sign up for or expire.
 
 ## Technology
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -8,7 +8,11 @@ describe('App', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve({ news: [] }) })
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ liberal: [], conservative: [], neutral: [] }),
+        })
       )
     );
   });

--- a/src/components/ArticleCard.jsx
+++ b/src/components/ArticleCard.jsx
@@ -38,7 +38,7 @@ export default function ArticleCard({ article }) {
   const { isSaved, toggleSave } = useSavedArticles();
   const [saveError, setSaveError] = useState(false);
   const saved = isSaved(article.url);
-  const source = sourceForUrl(article.url);
+  const source = article.source || sourceForUrl(article.url);
   const published = timeAgo(article.published);
 
   const handleToggle = async () => {

--- a/src/components/ArticleCard.test.jsx
+++ b/src/components/ArticleCard.test.jsx
@@ -14,9 +14,23 @@ describe('ArticleCard', () => {
     expect(headline).toHaveAttribute('target', '_blank');
   });
 
-  it('shows the source domain', () => {
+  it('falls back to the URL domain when no source name is stored', () => {
     renderWithProviders(<ArticleCard article={sampleArticle} />);
     expect(screen.getByText(/npr\.org/)).toBeInTheDocument();
+  });
+
+  it('prefers the stored source name over the URL domain', () => {
+    renderWithProviders(
+      <ArticleCard
+        article={{
+          ...sampleArticle,
+          source: 'NPR',
+          url: 'https://news.google.com/rss/articles/abc',
+        }}
+      />
+    );
+    expect(screen.getByText(/NPR/)).toBeInTheDocument();
+    expect(screen.queryByText(/news\.google\.com/)).not.toBeInTheDocument();
   });
 
   it('bookmarks and un-bookmarks as a guest without any network', async () => {

--- a/src/context/SavedArticlesContext.jsx
+++ b/src/context/SavedArticlesContext.jsx
@@ -33,8 +33,8 @@ export function SavedArticlesProvider({ children }) {
         const guestSaves = GuestSaves.get();
         if (guestSaves.length > 0) {
           await Promise.allSettled(
-            guestSaves.map(({ title, url, image }) =>
-              NewsfulApi.saveArticle(token, { title, url, image })
+            guestSaves.map(({ title, url, image, source }) =>
+              NewsfulApi.saveArticle(token, { title, url, image, source })
             )
           );
           GuestSaves.clear();
@@ -70,6 +70,7 @@ export function SavedArticlesProvider({ children }) {
         title: article.title,
         url: article.url,
         image: article.image ?? null,
+        source: article.source ?? null,
       };
       if (token) {
         const saved = await NewsfulApi.saveArticle(token, record);

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -37,6 +37,12 @@
   padding-top: 1rem;
 }
 
+.slow-hint {
+  text-align: center;
+  color: var(--text-muted);
+  margin: 0 1rem;
+}
+
 .page-error {
   text-align: center;
   padding: 2rem 1rem;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -26,11 +26,15 @@ export default function HomePage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [isSlow, setIsSlow] = useState(false);
 
   useEffect(() => {
     const abortController = new AbortController();
     setIsLoading(true);
     setError(null);
+    setIsSlow(false);
+    // Free hosting spins the API down when idle; warn if the wake-up is slow
+    const slowTimer = setTimeout(() => setIsSlow(true), 6000);
 
     fetchNews(query || undefined, abortController.signal)
       .then((results) => {
@@ -41,9 +45,13 @@ export default function HomePage() {
         if (err.name === 'AbortError') return;
         setError('Couldn’t load the news right now. Please try again.');
         setIsLoading(false);
-      });
+      })
+      .finally(() => clearTimeout(slowTimer));
 
-    return () => abortController.abort();
+    return () => {
+      clearTimeout(slowTimer);
+      abortController.abort();
+    };
   }, [query, refreshKey]);
 
   return (
@@ -78,6 +86,12 @@ export default function HomePage() {
 
         {isLoading ? (
           <div className="rows">
+            {isSlow && (
+              <p className="slow-hint">
+                Waking up the news server — the first load of the day can take
+                up to a minute…
+              </p>
+            )}
             {LANES.map((lane) => (
               <SkeletonRow key={lane.id} />
             ))}

--- a/src/pages/HomePage.test.jsx
+++ b/src/pages/HomePage.test.jsx
@@ -3,29 +3,31 @@ import { screen } from '@testing-library/react';
 import HomePage from './HomePage';
 import { renderWithProviders } from '../test/test-utils';
 
-const fakeNewsResponse = (domain) => ({
-  ok: true,
-  json: () =>
-    Promise.resolve({
-      news: [
-        {
-          title: `Top story from ${domain}`,
-          url: `https://${domain}/story`,
-          image: null,
-          published: '2026-07-03 04:12:11 +0000',
-        },
-      ],
-    }),
+const laneArticle = (lane, source) => ({
+  title: `Top story from ${source}`,
+  url: `https://news.google.com/rss/articles/${lane}-story`,
+  image: null,
+  source,
+  published: '2026-07-03T04:12:11.000Z',
+  lane,
 });
+
+const fakeNewsResponse = {
+  liberal: [laneArticle('liberal', 'MSNBC')],
+  conservative: [laneArticle('conservative', 'Fox News')],
+  neutral: [laneArticle('neutral', 'NPR')],
+};
 
 describe('HomePage', () => {
   beforeEach(() => {
     vi.stubGlobal(
       'fetch',
-      vi.fn((url) => {
-        const domain = new URL(url).searchParams.get('domain').split(',')[0];
-        return Promise.resolve(fakeNewsResponse(domain));
-      })
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(fakeNewsResponse),
+        })
+      )
     );
   });
 
@@ -45,9 +47,18 @@ describe('HomePage', () => {
     expect(
       screen.getByRole('heading', { name: 'Neutral' })
     ).toBeInTheDocument();
-    expect(screen.getByText('Top story from msnbc.com')).toBeInTheDocument();
-    expect(screen.getByText('Top story from foxnews.com')).toBeInTheDocument();
-    expect(screen.getByText('Top story from bbc.com')).toBeInTheDocument();
+    expect(screen.getByText('Top story from MSNBC')).toBeInTheDocument();
+    expect(screen.getByText('Top story from Fox News')).toBeInTheDocument();
+    expect(screen.getByText('Top story from NPR')).toBeInTheDocument();
+  });
+
+  it('requests news from the Newsful API with the search query', async () => {
+    renderWithProviders(<HomePage />);
+    await screen.findByRole('heading', { name: 'Liberal' });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/news$/),
+      expect.anything()
+    );
   });
 
   it('shows an error state with retry when the news API is down', async () => {

--- a/src/services/news-api.js
+++ b/src/services/news-api.js
@@ -1,34 +1,26 @@
-// Client for the Currents news API (https://currentsapi.services).
-// Newsful fetches each political "lane" separately so every lane always has
-// enough stories, then tags articles with the lane they came from.
-
-const API_KEY =
-  import.meta.env.VITE_CURRENTS_API_KEY ||
-  'U-KpTJ3lU2QW7BjPvER-ArREpL9Le5wHQ-KdFLco52cBbJe7';
-
-const BASE_URL = 'https://api.currentsapi.services/v1';
+// News comes from the Newsful API, which aggregates free Google News RSS
+// feeds per outlet — no metered news-API key to expire.
+import config from '../config';
 
 export const LANES = [
   {
     id: 'liberal',
     label: 'Liberal',
-    requestDomains: 'msnbc.com,huffpost.com',
     matchDomains: ['msnbc.com', 'huffpost.com', 'cnn.com'],
   },
   {
     id: 'conservative',
     label: 'Conservative',
-    requestDomains: 'foxnews.com,breitbart.com',
     matchDomains: ['foxnews.com', 'breitbart.com', 'nationalreview.com'],
   },
   {
     id: 'neutral',
     label: 'Neutral',
-    requestDomains: 'bbc.com,npr.org',
     matchDomains: ['bbc.com', 'npr.org', 'reuters.com'],
   },
 ];
 
+// Lane accent for articles saved before sources were stored.
 export function laneForUrl(url = '') {
   const lane = LANES.find(({ matchDomains }) =>
     matchDomains.some((domain) => url.includes(domain))
@@ -44,46 +36,16 @@ export function sourceForUrl(url = '') {
   }
 }
 
-function normalizeArticle(article, laneId) {
-  return {
-    title: article.title,
-    url: article.url,
-    // Currents sometimes returns the literal string "None" for missing images
-    image:
-      article.image && article.image !== 'None' && article.image !== 'null'
-        ? article.image
-        : null,
-    published: article.published || null,
-    lane: laneId,
-  };
-}
-
-async function fetchLane(lane, query, signal) {
+// Returns { liberal: [...], conservative: [...], neutral: [...] }.
+// Omit `query` for today's top stories.
+export async function fetchNews(query, signal) {
   const url = query
-    ? `${BASE_URL}/search?apiKey=${API_KEY}&domain=${lane.requestDomains}&keywords=${encodeURIComponent(query)}`
-    : `${BASE_URL}/latest-news?apiKey=${API_KEY}&domain=${lane.requestDomains}`;
+    ? `${config.API_ENDPOINT}/news?q=${encodeURIComponent(query)}`
+    : `${config.API_ENDPOINT}/news`;
 
   const response = await fetch(url, { signal });
   if (!response.ok) {
     throw new Error(`News request failed (${response.status})`);
   }
-  const data = await response.json();
-
-  const seen = new Set();
-  return (data.news || [])
-    .filter((article) => {
-      if (!article.title || !article.url || seen.has(article.url)) return false;
-      seen.add(article.url);
-      return true;
-    })
-    .map((article) => normalizeArticle(article, lane.id));
-}
-
-// Returns { liberal: [...], conservative: [...], neutral: [...] }.
-// Omit `query` for today's top headlines.
-export async function fetchNews(query, signal) {
-  const results = await Promise.all(
-    LANES.map((lane) => fetchLane(lane, query, signal))
-  );
-  return Object.fromEntries(LANES.map((lane, i) => [lane.id, results[i]]));
+  return response.json();
 }

--- a/src/services/newsful-api.js
+++ b/src/services/newsful-api.js
@@ -56,11 +56,11 @@ const NewsfulApi = {
     return request('/saved-articles', { token });
   },
 
-  saveArticle(token, { title, url, image }) {
+  saveArticle(token, { title, url, image, source }) {
     return request('/saved-articles', {
       method: 'POST',
       token,
-      body: JSON.stringify({ title, url, image }),
+      body: JSON.stringify({ title, url, image, source }),
     });
   },
 


### PR DESCRIPTION
The bundled Currents API key stopped working. News now comes from the Newsful API's new `GET /api/news` endpoint, which aggregates free Google News RSS feeds — no news-API key anywhere in the stack anymore.

- Cards prefer the stored source name ("Fox News") over the URL domain, since Google News article links all live on news.google.com
- Bookmarks store the source, so the saved page shows it too (guest saves included; merged saves carry it to the server)
- After 6 seconds of loading, the home page explains that the free-tier server is waking up (news now flows through Render, which sleeps when idle)

15 tests passing; verified in-browser: lanes render with source names, bookmarking keeps the source on the saved page, search flows through `?q=`.

Depends on lyunya/newsful-api PR "Serve news from Google News RSS via GET /api/news" — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR)_