### PR TITLE
Point the default API endpoint at Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Optional environment variables (put them in `.env.local`):
 
 | Variable | Purpose | Default |
 | --- | --- | --- |
-| `VITE_API_ENDPOINT` | Newsful API base URL | `https://newsful-api.onrender.com/api` |
+| `VITE_API_ENDPOINT` | Newsful API base URL | `https://newsful-api.vercel.app/api` |
 
 News comes from the Newsful API, which aggregates free Google News RSS feeds per outlet — there is no news-API key to sign up for or expire.
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const config = {
   API_ENDPOINT:
-    import.meta.env.VITE_API_ENDPOINT || 'https://newsful-api.onrender.com/api',
+    import.meta.env.VITE_API_ENDPOINT || 'https://newsful-api.vercel.app/api',
   TOKEN_KEY: 'newsful-auth-token',
   USER_KEY: 'newsful-user',
   GUEST_SAVES_KEY: 'newsful-guest-saves',


### PR DESCRIPTION
The API moved from Render to Vercel serverless (`newsful-api.vercel.app`). This updates the default `API_ENDPOINT`; override with `VITE_API_ENDPOINT` in Vercel project settings if the API deployment's URL differs.

Pairs with lyunya/newsful-api PR "Run on Vercel serverless (with Neon Postgres)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR)_